### PR TITLE
[mining] add signature mining ed25519 and ecdsa

### DIFF
--- a/benches/mining.rs
+++ b/benches/mining.rs
@@ -6,6 +6,7 @@ mod mining_benches {
     use criterion::*;
     use fastcrypto::{ed25519::Ed25519KeyPair, secp256k1::Secp256k1KeyPair, traits::KeyPair};
     use rand::{prelude::ThreadRng, thread_rng};
+    use signature::Signer;
 
     fn key_generation(c: &mut Criterion) {
         // Note that for 3 bytes, benchmarks are very slow.
@@ -19,7 +20,7 @@ mod mining_benches {
                 &("Ed25519_keypair_gen_zerobytes=".to_owned() + &num.to_string()),
                 move |b| {
                     b.iter(|| loop {
-                        if Ed25519KeyPair::generate(&mut csprng1).public().as_ref()[..num]
+                        if Ed25519KeyPair::generate(&mut csprng1).public().as_ref()[1..=num]
                             == vec![0u8; num]
                         {
                             break;
@@ -27,6 +28,7 @@ mod mining_benches {
                     })
                 },
             );
+
             c.bench_function(
                 &("ECDSA_secp256k1_keypair_gen_zerobytes=".to_owned() + &num.to_string()),
                 move |b| {
@@ -42,11 +44,62 @@ mod mining_benches {
         }
     }
 
+    fn signing(c: &mut Criterion) {
+        // Note that for 3 bytes, benchmarks are very slow.
+        const FIXED_BYTES_NUM: [usize; 3] = [1, 2, 3];
+
+        for num in FIXED_BYTES_NUM {
+            let mut csprng1: ThreadRng = thread_rng();
+            let mut csprng2 = csprng1.clone();
+            let ed25519_keypair = Ed25519KeyPair::generate(&mut csprng1);
+            let ecdsa_keypair = Secp256k1KeyPair::generate(&mut csprng2);
+            let mut counter = 0u64;
+
+            c.bench_function(
+                &("Ed25519_sign_zerobytes=".to_owned() + &num.to_string()),
+                move |b| {
+                    b.iter(|| loop {
+                        // Note that ed25519 signing is deterministic, thus we retry with a counter.
+                        counter = rand::random();
+                        if ed25519_keypair
+                            .try_sign(&counter.to_le_bytes())
+                            .unwrap()
+                            .as_ref()[1..=num]
+                            == vec![0u8; num]
+                        {
+                            break;
+                        }
+                    })
+                },
+            );
+
+            c.bench_function(
+                &("ECDSA_secp256k1_sign_zerobytes=".to_owned() + &num.to_string()),
+                move |b| {
+                    b.iter(|| loop {
+                        // Note that fastcrypto's ecdsa signing is deterministic, thus we retry
+                        // with a counter.
+                        counter = rand::random();
+                        if ecdsa_keypair
+                            .try_sign(&counter.to_le_bytes())
+                            .unwrap()
+                            .as_ref()[1..=num]
+                            == vec![0u8; num]
+                        {
+                            break;
+                        }
+                    })
+                },
+            );
+        }
+    }
+
     criterion_group! {
         name = mining_benches;
         config = Criterion::default().significance_level(0.1).sample_size(10);
         targets =
             key_generation,
+            signing,
     }
 }
 


### PR DESCRIPTION
Results in Mac Pro M1 Max
```
Ed25519_sign_zerobytes=1
                        time:   [3.0588 ms 3.1806 ms 3.3018 ms]

ECDSA_secp256k1_sign_zerobytes=1
                        time:   [14.420 ms 16.631 ms 18.081 ms]

Ed25519_sign_zerobytes=2
                        time:   [474.52 ms 817.07 ms 1.2234 s]

ECDSA_secp256k1_sign_zerobytes=2
                        time:   [2.9633 s 6.6308 s 12.320 s]
```
 Results are fine by just extrapolating to the single byte ms * 256^b per extra byte b           
 